### PR TITLE
Control the log level from command line

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 from logging.handlers import RotatingFileHandler
 from time import sleep
@@ -10,9 +11,9 @@ from algo import Sampler
 from sound import SoundDevice
 
 
-def configure_logging(store):
+def configure_logging(level, store):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(level)
     # create file handler which logs even debug messages
     fh = RotatingFileHandler('inhalator.log', maxBytes=1024 * 100, backupCount=3)
     fh.setLevel(logging.ERROR)
@@ -30,9 +31,19 @@ def configure_logging(store):
     logger.disabled = not store.log_enabled
 
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", "-v", action="count", default=0)
+    args = parser.parse_args()
+    args.verbose = max(0, logging.WARNING - (10 * args.verbose))
+    print("Computed level is {}".format(args.verbose))
+    return args
+
+
 def main():
+    args = parse_args()
     store = DataStore()
-    configure_logging(store)
+    configure_logging(args.verbose, store)
     sound_device = SoundDevice()
     store.alerts_queue.subscribe(sound_device, sound_device.on_alert)
 

--- a/main.py
+++ b/main.py
@@ -36,7 +36,6 @@ def parse_args():
     parser.add_argument("--verbose", "-v", action="count", default=0)
     args = parser.parse_args()
     args.verbose = max(0, logging.WARNING - (10 * args.verbose))
-    print("Computed level is {}".format(args.verbose))
     return args
 
 


### PR DESCRIPTION
# Purpose
Enable manipulate log levels from the command line.
basically add more 'v' to the start parameters will increase the log level to higher verbosity.
The default level without any `-v` is `WARNING`

# Examples:
default is to log warning and up
```sh
 python main.py
 ```
will log INFO level
```sh
 python main.py -v
```
will log DEBUG level
```sh
 python main.py -vv
```
will log everything
```sh
 python main.py -vvv
```