### PR TITLE
Moved wd refresh to the main loop

### DIFF
--- a/application.py
+++ b/application.py
@@ -32,6 +32,7 @@ class Application(object):
         self.should_run = True
         self.drivers = drivers
         self.sampler = sampler
+        self.arm_wd_event = arm_wd_event
         self.root = Tk()
         self.theme = Theme.toggle_theme()  # Set to dark mode, TODO: Make this configurable
         self.root.protocol("WM_DELETE_WINDOW", self.exit)  # Catches Alt-F4
@@ -47,7 +48,7 @@ class Application(object):
         if Configurations.configuration_state() == ConfigurationState.CONFIG_CORRUPTED:
             events.alerts_queue.enqueue_alert(AlertCodes.NO_CONFIGURATION_FILE)
 
-        self.master_frame = MasterFrame(self.root, arm_wd_event=arm_wd_event,
+        self.master_frame = MasterFrame(self.root,
                                         measurements=measurements,
                                         events=events,
                                         drivers=drivers)
@@ -70,6 +71,7 @@ class Application(object):
             try:
                 self.sampler.sampling_iteration()
                 self.gui_update()
+                self.arm_wd_event.set()
             except KeyboardInterrupt:
                 break
         self.exit()

--- a/data/measurements.py
+++ b/data/measurements.py
@@ -5,7 +5,7 @@ from data.configurations import Configurations
 
 
 class Measurements(object):
-    SYSTEM_SAMPLE_INTERVAL = 22  # KHZ
+    SYSTEM_SAMPLE_INTERVAL = 22  # HZ
     MS_TO_SEC = 1000
 
     def __init__(self):

--- a/graphics/graphs.py
+++ b/graphics/graphs.py
@@ -9,7 +9,6 @@ from graphics.themes import Theme
 
 if platform.python_version() < '3':
     from Tkinter import *
-
 else:
     from tkinter import *
 

--- a/graphics/panes.py
+++ b/graphics/panes.py
@@ -19,13 +19,13 @@ from graphics.themes import Theme
 
 
 class MasterFrame(object):
-    def __init__(self, root, arm_wd_event, drivers, events, measurements):
+    def __init__(self, root, drivers, events, measurements):
         self.root = root
 
         self.master_frame = Frame(master=self.root, bg="black")
         self.left_pane = LeftPane(self, measurements=measurements)
         self.right_pane = RightPane(self, events=events)
-        self.center_pane = CenterPane(self, arm_wd_event=arm_wd_event, measurements=measurements)
+        self.center_pane = CenterPane(self, measurements=measurements)
         self.top_pane = TopPane(self, events=events, drivers=drivers)
 
     @property
@@ -90,9 +90,8 @@ class LeftPane(object):
 
 
 class CenterPane(object):
-    def __init__(self, parent, arm_wd_event, measurements):
+    def __init__(self, parent, measurements):
         self.parent = parent
-        self.arm_wd_event = arm_wd_event
         self.measurements = measurements
 
         self.root = parent.element
@@ -141,10 +140,6 @@ class CenterPane(object):
         for graph in self.graphs:
             graph.update()
 
-        # arm wd only if both queues had sampling values
-        if had_flow_change and had_pressure_change:
-            self.arm_wd_event.set()
-
 
 class RightPane(object):
     def __init__(self, parent, events):
@@ -165,7 +160,6 @@ class RightPane(object):
         self.clear_alerts_btn = ClearAlertsButton(parent=self, events=self.events)
         self.lock_thresholds_btn = LockThresholdsButton(parent=self)
         self.configure_alerts_btn = OpenConfigureAlertsScreenButton(self)
-
 
     @property
     def buttons(self):


### PR DESCRIPTION
# Motivation
Right now the WD logic was baked into the class the presents the actual graphs itself, no less.
This is a sever coupling of UI and application logic. 

The WD is designed to alert if the **application** is stuck.

This is why I extracted the WD logic to the application's main loop. On each iteration, after everything else has been dealt with, we kick the dog.

More lines of code have been deleted than added - and the functionality kept the same.