### PR TITLE
It is the time of Python 3

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,11 +1,5 @@
-# Tkinter stuff
 import os
-import platform
-
-if platform.python_version() < '3':
-    from Tkinter import *
-else:
-    from tkinter import *
+from tkinter import *
 
 from graphics.panes import MasterFrame
 from graphics.themes import Theme, DarkTheme

--- a/data/configurations.py
+++ b/data/configurations.py
@@ -107,9 +107,9 @@ class Configurations(object):
                                              max=config["threshold"]["bpm"]["max"],
                                              step=config["threshold"]["bpm"]["step"])
 
-            flow_y_scale = (config["graph_y_scale"]["flow"]["min"], \
+            flow_y_scale = (config["graph_y_scale"]["flow"]["min"],
                             config["graph_y_scale"]["flow"]["max"])
-            pressure_y_scale = (config["graph_y_scale"]["pressure"]["min"], \
+            pressure_y_scale = (config["graph_y_scale"]["pressure"]["min"],
                                 config["graph_y_scale"]["pressure"]["max"])
 
             graph_seconds = config["graph_seconds"]
@@ -131,8 +131,8 @@ class Configurations(object):
                        pressure_y_scale=pressure_y_scale)
 
         except Exception as e:
-            raise ConfigurationFileError("Could not load config file %s"
-                                         % config_file) from e
+            raise ConfigurationFileError(f"Could not load "
+                                         f"config file {config_file}") from e
 
     def save_to_file(self, config_path=CONFIG_FILE):
         log.info("Saving threshold values to database")

--- a/drivers/abp_pressure_sensor.py
+++ b/drivers/abp_pressure_sensor.py
@@ -24,7 +24,7 @@ class AbpPressureSensor(object):
             self._pig = pigpio.pi()
         except pigpio.error as e:
             log.error("Could not init pigpio lib. Did you run 'sudo pigpiod'?")
-            raise PiGPIOInitError("pigpio library init error")
+            raise PiGPIOInitError("pigpio library init error") from e
 
         if self._pig is None:
             log.error("Could not init pigpio lib. Did you run 'sudo pigpiod'?")
@@ -32,14 +32,14 @@ class AbpPressureSensor(object):
 
         try:
             self._dev = self._pig.i2c_open(self.I2C_BUS, self.I2C_ADDRESS)
-        except AttributeError:
+        except AttributeError as e:
             log.error("Could not init pigpio lib. Did you run 'sudo pigpiod'?")
-            raise PiGPIOInitError("pigpio library init error")
+            raise PiGPIOInitError("pigpio library init error") from e
 
-        except pigpio.error:
+        except pigpio.error as e:
             log.error("Could not open i2c connection to pressure sensor."
                       "Is it connected?")
-            raise I2CDeviceNotFoundError("i2c connection open failed")
+            raise I2CDeviceNotFoundError("i2c connection open failed") from e
 
         log.info("ABP pressure sensor initialized")
 
@@ -63,4 +63,4 @@ class AbpPressureSensor(object):
         except pigpio.error as e:
             log.error("Could not read from pressure sensor. "
                       "Is the pressure sensor connected?.")
-            raise I2CReadError("i2c write failed")
+            raise I2CReadError("i2c write failed") from e

--- a/drivers/driver_factory.py
+++ b/drivers/driver_factory.py
@@ -49,10 +49,10 @@ class DriverFactory(object):
         driver = self.drivers_cache.get(key)
         if driver is not None:
             return driver
-        method_name = "get{}_{}_driver".format(("_mock" if self.mock else ""), driver_name)
+        method_name = f"get{'_mock' if self.mock else ''}_{driver_name}_driver"
         method = getattr(self, method_name, None)
         if method is None:
-            raise ValueError("Unsupported driver {}".format(driver_name))
+            raise ValueError(f"Unsupported driver {driver_name}")
         driver = method()
         self.drivers_cache[key] = driver
         return driver

--- a/drivers/hce_pressure_sensor.py
+++ b/drivers/hce_pressure_sensor.py
@@ -33,20 +33,20 @@ class HcePressureSensor(object):
         except IOError as e:
             log.error("Couldn't init spi device, \
                 is the peripheral initialized?")
-            raise SPIDriverInitError("spidev peripheral init error")
+            raise SPIDriverInitError("spidev peripheral init error") from e
 
         try:
             self._spi.max_speed_hz = self.SPI_CLK_SPEED_KHZ
         except IOError as e:
             log.error("setting spi speed failed, \
                 is speed in the correct range?")
-            raise SPIDriverInitError("spidev peripheral init error")
+            raise SPIDriverInitError("spidev peripheral init error") from e
 
         try:
             self._spi.mode = self.SPI_MODE
         except TypeError as e:
-            log.error(e.strerror)
-            raise SPIDriverInitError("spi mode error")
+            log.exception(e)
+            raise SPIDriverInitError("spi mode error") from e
 
         log.info("HCE pressure sensor initialized")
 
@@ -66,7 +66,7 @@ class HcePressureSensor(object):
                     self.PERIPHERAL_MINIMAL_DELAY)
         except IOError as e:
             log.error("Failed to read pressure sensor. check if peripheral is initialized correctly")
-            raise SPIIOError("hce spi read error")
+            raise SPIIOError("hce spi read error") from e
 
         pressure_reading = (pressure_raw[1] << 8) | (pressure_raw[2])
         pressure_parsed = self._calculate_pressure(pressure_reading)

--- a/drivers/sfm3200_flow_sensor.py
+++ b/drivers/sfm3200_flow_sensor.py
@@ -28,7 +28,7 @@ class Sfm3200(object):
             self._pig = pigpio.pi()
         except pigpio.error as e:
             log.error("Could not init pigpio lib. Did you run 'sudo pigpiod'?")
-            raise PiGPIOInitError("pigpio library init error")
+            raise PiGPIOInitError("pigpio library init error") from e
 
         if self._pig is None:
             log.error("Could not init pigpio lib. Did you run 'sudo pigpiod'?")
@@ -36,14 +36,14 @@ class Sfm3200(object):
 
         try:
             self._dev = self._pig.i2c_open(self.I2C_BUS, self.I2C_ADDRESS)
-        except AttributeError:
+        except AttributeError as e:
             log.error("Could not init pigpio lib. Did you run 'sudo pigpiod'?")
-            raise PiGPIOInitError("pigpio library init error")
+            raise PiGPIOInitError("pigpio library init error") from e
 
-        except pigpio.error:
+        except pigpio.error as e:
             log.error("Could not open i2c connection to flow sensor."
                       "Is it connected?")
-            raise I2CDeviceNotFoundError("i2c connection open failed")
+            raise I2CDeviceNotFoundError("i2c connection open failed") from e
 
         self._start_measure()
         sleep(0.1)
@@ -54,8 +54,7 @@ class Sfm3200(object):
                       "Is it connected?")
             raise I2CDeviceNotFoundError("i2c read failed")
 
-        log.debug("Flow sensor: Successfully read dummy values: {}"
-                  .format(dummy))
+        log.debug(f"Flow sensor: Successfully read dummy values: {dummy}")
 
     # Todo: Implement read serial number command
 
@@ -65,7 +64,7 @@ class Sfm3200(object):
         except pigpio.error as e:
             log.error("Could not write start_measure cmd to flow sensor. "
                       "Is the flow sensor connected?.")
-            raise I2CWriteError("i2c write failed")
+            raise I2CWriteError("i2c write failed") from e
 
         log.info("Started flow sensor measurement")
 
@@ -74,7 +73,7 @@ class Sfm3200(object):
             self._pig.i2c_write_device(self._dev, self.SOFT_RST_CMD)
         except pigpio.error as e:
             log.error("Could not write soft reset cmd to flow sensor.")
-            raise I2CWriteError("i2c write failed")
+            raise I2CWriteError("i2c write failed") from e
 
     def read(self, retries=2):
         read_size, data = self._pig.i2c_read_device(self._dev, 3)
@@ -85,13 +84,13 @@ class Sfm3200(object):
                 expected_crc = data[2]
                 crc_calc = self._crc8(data[:2])
                 if not crc_calc == expected_crc:
-                    log.error("CRC mismatch while reading data from flow sensor."
-                              "{} - expected {}".format(crc_calc, expected_crc))
+                    log.error(f"CRC mismatch while reading data from flow sensor."
+                              "{crc_calc} - expected {expected_crc}")
                     raise FlowSensorCRCError("CRC mismatch")
 
             else:
-                log.error("Too much data recieved, "
-                          "got {} expected 3. data: {}".format(len(data), data))
+                log.error(f"Too much data recieved, "
+                          "got {len(data)} expected 3. data: {data}")
                 raise I2CReadError("Too much data read, invalid state")
 
         elif read_size == 0:
@@ -122,7 +121,7 @@ class Sfm3200(object):
 
         # Normalize flow to slm units
         flow = float(raw_value - self.OFFSET_FLOW) / self.SCALE_FACTOR_FLOW
-        log.debug("Flow sensor value: {} slm. CRC correct".format(flow))
+        log.debug(f"Flow sensor value: {flow} slm. CRC correct")
         return flow
 
     def _crc8(self, data):

--- a/graphics/alert_bar.py
+++ b/graphics/alert_bar.py
@@ -1,19 +1,10 @@
 import time
-# Tkinter stuff
-import platform
+from tkinter import *
+
 
 from graphics.themes import Theme
-
-if platform.python_version() < '3':
-    from Tkinter import *
-
-else:
-    from tkinter import *
-
 from data import alerts, events, configurations
-
 from drivers.driver_factory import DriverFactory
-
 from data.configurations import Configurations
 
 

--- a/graphics/configure_alerts_screen.py
+++ b/graphics/configure_alerts_screen.py
@@ -1,16 +1,10 @@
 import os
-import platform
 
 from cached_property import cached_property
 
-# Tkinter stuff
 from data.configurations import Configurations
 
-if platform.python_version() < '3':
-    from Tkinter import *
-
-else:
-    from tkinter import *
+from tkinter import *
 
 from data.thresholds import (VolumeRange, PressureRange,
                              RespiratoryRateRange, FlowRange)
@@ -112,8 +106,8 @@ class Section(object):
         self.range.load_from(self.original_range)
 
     def update(self):
-        self.max_button.configure(text="MAX\n{}".format(self.range.max))
-        self.min_button.configure(text="MIN\n{}".format(self.range.min))
+        self.max_button.configure(text=f"MAX\n{self.range.max}")
+        self.min_button.configure(text=f"MIN\n{self.range.min}")
 
     def render(self):
         self.frame.place(relx=(0.2) * self.INDEX,
@@ -126,8 +120,8 @@ class Section(object):
 
         self.name_label.configure(text=self.range.NAME)
         self.unit_label.configure(text=self.range.UNIT)
-        self.max_button.configure(text="MAX\n{}".format(self.range.max))
-        self.min_button.configure(text="MIN\n{}".format(self.range.min))
+        self.max_button.configure(text=f"MAX\n{self.range.max}")
+        self.min_button.configure(text=f"MIN\n{self.range.min}")
 
 
 class VTISection(Section):

--- a/graphics/graph_summaries.py
+++ b/graphics/graph_summaries.py
@@ -1,13 +1,6 @@
-# Tkinter stuff
-import platform
-
 from graphics.themes import Theme
 
-if platform.python_version() < '3':
-    from Tkinter import *
-
-else:
-    from tkinter import *
+from tkinter import *
 
 
 class GraphSummary(object):

--- a/graphics/graphs.py
+++ b/graphics/graphs.py
@@ -2,16 +2,10 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
 from matplotlib import rcParams
 
-# Tkinter stuff
-import platform
-
 from data.configurations import Configurations
 from graphics.themes import Theme
 
-if platform.python_version() < '3':
-    from Tkinter import *
-else:
-    from tkinter import *
+from tkinter import *
 
 
 class BlankGraph(object):

--- a/graphics/panes.py
+++ b/graphics/panes.py
@@ -1,11 +1,4 @@
-# Tkinter stuff
-import platform
-
-if platform.python_version() < '3':
-    from Tkinter import *
-
-else:
-    from tkinter import *
+from tkinter import *
 
 from graphics.alert_bar import IndicatorAlertBar
 from graphics.graphs import FlowGraph, AirPressureGraph, BlankGraph

--- a/graphics/right_menu_options.py
+++ b/graphics/right_menu_options.py
@@ -1,22 +1,12 @@
-# Tkinter stuff
 import os
-import platform
 
 import time
 from graphics.configure_alerts_screen import ConfigureAlarmsScreen
 from graphics.imagebutton import ImageButton
 
-if platform.python_version() < '3':
-    from Tkinter import *
-
-else:
-    from tkinter import *
+from tkinter import *
 
 from graphics.themes import Theme
-
-THIS_DIRECTORY = os.path.dirname(__file__)
-RESOURCES_DIRECTORY = os.path.join(os.path.dirname(THIS_DIRECTORY), "resources")
-
 
 THIS_DIRECTORY = os.path.dirname(__file__)
 RESOURCES_DIRECTORY = os.path.join(os.path.dirname(THIS_DIRECTORY), "resources")

--- a/main.py
+++ b/main.py
@@ -27,8 +27,8 @@ class BroadcastHandler(logging.handlers.DatagramHandler):
             super().send(s)
 
         except OSError as e:
-            if e.errno != 101:  # Network is unreachable
-                raise e
+            if e.errno != 101:
+                raise RuntimeError("Network is unreachable") from e
 
     def makeSocket(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
As a pre-emptive state to tinkering with `tkinter` (:rofl:) , I wanted to fix some imports, and along the way changed multiple Python 2.7 ugly stuff.

This includes:
* Exceptions withholding full traceback
* Using `.format()` rather than f-strings
* Python 2.7 `tkiner` run-time imports