### PR TITLE
Unit-tests for Configure Alerts Screen 

### DIFF
--- a/data/thresholds.py
+++ b/data/thresholds.py
@@ -41,7 +41,8 @@ class Range(object):
         self.max = other.max
 
     def increase_min(self):
-        self.min += self.step
+        if self.min + self.step <= self.max:
+            self.min += self.step
 
     def increase_max(self):
         self.max += self.step
@@ -50,7 +51,8 @@ class Range(object):
         self.min -= self.step
 
     def decrease_max(self):
-        self.max -= self.step
+        if self.max - self.step >= self.min:
+            self.max -= self.step
 
 
 class FlowRange(Range):

--- a/graphics/configure_alerts_screen.py
+++ b/graphics/configure_alerts_screen.py
@@ -29,13 +29,6 @@ class ThresholdButton(Button):
                        command=self.publish)
         self.subscribers = {}
 
-    def toggle(self):
-        if self.selected:
-            self.deselect()
-
-        else:
-            self.select()
-
     @property
     def selected(self):
         return self["bg"] == "#52475d"

--- a/tests/unit/graphics/test_configure_alerts_screen.py
+++ b/tests/unit/graphics/test_configure_alerts_screen.py
@@ -64,3 +64,30 @@ def test_pressing_the_same_range_makes_nothing_selected(screen: ConfigureAlarmsS
     screen.pressure_section.max_button.publish()
     screen.pressure_section.max_button.publish()
     assert screen.selected_threshold == None
+
+def test_minimum_cant_go_over_maximum(screen: ConfigureAlarmsScreen):
+    config = Configurations.instance()
+    config.pressure_range.min = 0
+    config.pressure_range.max = 0
+    screen.pressure_section.min_button.publish()  # Click the min button
+    screen.on_up_button_click()  # Raise it
+
+    assert config.pressure_range.min == 0
+
+    # Revert changes since Configurations is a Singleton and we don't
+    # want it to interact with other tests
+    screen.cancel()
+
+
+def test_maxmimum_cant_go_under_minimum(screen: ConfigureAlarmsScreen):
+    config = Configurations.instance()
+    config.pressure_range.min = 0
+    config.pressure_range.max = 0
+    screen.pressure_section.max_button.publish()  # Click the min button
+    screen.on_down_button_click()  # Lower it
+
+    assert config.pressure_range.max == 0
+
+    # Revert changes since Configurations is a Singleton and we don't
+    # want it to interact with other tests
+    screen.cancel()

--- a/tests/unit/graphics/test_configure_alerts_screen.py
+++ b/tests/unit/graphics/test_configure_alerts_screen.py
@@ -15,13 +15,16 @@ def screen() -> ConfigureAlarmsScreen:
     Theme.ACTIVE_THEME = DarkTheme()
     return ConfigureAlarmsScreen(root=Frame())
 
+
 def test_changing_threshold_using_max_button(screen: ConfigureAlarmsScreen):
     screen.pressure_section.max_button.publish()
     assert screen.selected_threshold == Configurations.instance().pressure_range
 
+
 def test_changing_threshold_using_min_button(screen: ConfigureAlarmsScreen):
     screen.pressure_section.min_button.publish()
     assert screen.selected_threshold == Configurations.instance().pressure_range
+
 
 def test_up_down_buttons_on_min(screen: ConfigureAlarmsScreen):
     min_pressure = Configurations.instance().pressure_range.min
@@ -33,6 +36,7 @@ def test_up_down_buttons_on_min(screen: ConfigureAlarmsScreen):
     screen.on_down_button_click()
     assert Configurations.instance().pressure_range.min == min_pressure
 
+
 def test_up_down_buttons_on_max(screen: ConfigureAlarmsScreen):
     max_pressure = Configurations.instance().pressure_range.max
     step = Configurations.instance().pressure_range.step
@@ -42,6 +46,7 @@ def test_up_down_buttons_on_max(screen: ConfigureAlarmsScreen):
     assert Configurations.instance().pressure_range.max == max_pressure + step
     screen.on_down_button_click()
     assert Configurations.instance().pressure_range.max == max_pressure
+
 
 def test_pressing_cancel_undoes_everything(screen: ConfigureAlarmsScreen):
     max_pressure = Configurations.instance().pressure_range.max
@@ -53,3 +58,9 @@ def test_pressing_cancel_undoes_everything(screen: ConfigureAlarmsScreen):
     screen.cancel()
 
     assert Configurations.instance().pressure_range.max == max_pressure
+
+
+def test_pressing_the_same_range_makes_nothing_selected(screen: ConfigureAlarmsScreen):
+    screen.pressure_section.max_button.publish()
+    screen.pressure_section.max_button.publish()
+    assert screen.selected_threshold == None

--- a/tests/unit/graphics/test_configure_alerts_screen.py
+++ b/tests/unit/graphics/test_configure_alerts_screen.py
@@ -1,0 +1,55 @@
+import time
+from tkinter import Frame
+
+import pytest
+from unittest.mock import MagicMock
+
+from data.alerts import Alert, AlertCodes
+from data.configurations import Configurations
+from graphics.configure_alerts_screen import ConfigureAlarmsScreen
+from graphics.themes import Theme, DarkTheme
+
+
+@pytest.fixture
+def screen() -> ConfigureAlarmsScreen:
+    Theme.ACTIVE_THEME = DarkTheme()
+    return ConfigureAlarmsScreen(root=Frame())
+
+def test_changing_threshold_using_max_button(screen: ConfigureAlarmsScreen):
+    screen.pressure_section.max_button.publish()
+    assert screen.selected_threshold == Configurations.instance().pressure_range
+
+def test_changing_threshold_using_min_button(screen: ConfigureAlarmsScreen):
+    screen.pressure_section.min_button.publish()
+    assert screen.selected_threshold == Configurations.instance().pressure_range
+
+def test_up_down_buttons_on_min(screen: ConfigureAlarmsScreen):
+    min_pressure = Configurations.instance().pressure_range.min
+    step = Configurations.instance().pressure_range.step
+
+    screen.pressure_section.min_button.publish()
+    screen.on_up_button_click()
+    assert Configurations.instance().pressure_range.min == min_pressure + step
+    screen.on_down_button_click()
+    assert Configurations.instance().pressure_range.min == min_pressure
+
+def test_up_down_buttons_on_max(screen: ConfigureAlarmsScreen):
+    max_pressure = Configurations.instance().pressure_range.max
+    step = Configurations.instance().pressure_range.step
+
+    screen.pressure_section.max_button.publish()
+    screen.on_up_button_click()
+    assert Configurations.instance().pressure_range.max == max_pressure + step
+    screen.on_down_button_click()
+    assert Configurations.instance().pressure_range.max == max_pressure
+
+def test_pressing_cancel_undoes_everything(screen: ConfigureAlarmsScreen):
+    max_pressure = Configurations.instance().pressure_range.max
+
+    screen.pressure_section.max_button.publish()
+    screen.on_up_button_click()
+    screen.on_up_button_click()
+    screen.on_up_button_click()
+    screen.cancel()
+
+    assert Configurations.instance().pressure_range.max == max_pressure


### PR DESCRIPTION
# Coverage: 27% -> 37% 
# Functionalities tested
* Cancel button undoes all changes 
* Minimum can't go over maximum
* Maximum can't go under minimum
* Up/Down buttons change thresholds
* Clicking the same button twice makes no button selected 
* Basic functionality (Sanity) 

This solves https://github.com/Reznic/Inhalator/issues/140
