### PR TITLE
Time control: simulations are now deterministic

### DIFF
--- a/drivers/driver_factory.py
+++ b/drivers/driver_factory.py
@@ -1,5 +1,4 @@
 import csv
-from itertools import cycle
 
 from drivers.mocks.sinus import sinus, truncate, add_noise, zero
 
@@ -136,6 +135,19 @@ class DriverFactory(object):
             samples, lower_limit=self.MOCK_O2_SATURATION_LOWER_LIMIT,
             upper_limit=self.MOCK_O2_SATURATION_AMPLITUDE)
         return samples
+
+    @staticmethod
+    def get_timer_driver():
+        from drivers.timer import Timer
+        return Timer()
+
+    def get_mock_timer_driver(self):
+        from drivers.mocks.timer import MockTimer
+        if self.simulation_data == "sinus" or self.simulation_data == "dead":
+            time_series = [0, 1 / self.MOCK_SAMPLE_RATE_HZ]
+        else:
+            time_series = generate_data_from_file("time elapsed (seconds)", self.simulation_data)
+        return MockTimer(time_series=time_series)
 
     @staticmethod
     def get_pressure_driver():

--- a/drivers/mocks/timer.py
+++ b/drivers/mocks/timer.py
@@ -1,0 +1,19 @@
+from itertools import cycle
+
+
+class MockTimer(object):
+
+    def __init__(self, time_series):
+        if not hasattr(time_series, "__getitem__"):
+            time_series = list(time_series)
+        # We can't just cycle over the timestamp, because it doesn't make sense
+        # for time to wrap around. But it does make sense to cycle over the
+        # _intervals_ between the timestamps.
+        intervals = [j - i for i, j in zip(time_series[:-1], time_series[1:])]
+        self.intervals = cycle(intervals)
+        self.current_time = time_series[0]
+
+    def get_time(self):
+        current = self.current_time
+        self.current_time += next(self.intervals)
+        return current

--- a/drivers/timer.py
+++ b/drivers/timer.py
@@ -1,0 +1,8 @@
+import time
+
+
+class Timer(object):
+
+    @staticmethod
+    def get_time():
+        return time.time()

--- a/main.py
+++ b/main.py
@@ -53,7 +53,10 @@ def parse_args():
         "--error", "-e", type=float,
         help="The probability of error in each driver", default=0)
     sim_options.add_argument(
-        "--sample-rate", "-r", help="The sample rate of the simulation data",
+        "--sample-rate", "-r",
+        help="The speed, in samples-per-seconds, in which the simulation will "
+             "be played at. Useful for slowing down the simulation to see what "
+             "is going on, or speeding up to run simulation faster",
         type=float, default=22)
     parser.add_argument(
         "--fps", "-f",
@@ -93,10 +96,11 @@ def main():
 
     watchdog = drivers.get_driver("wd")
     oxygen_a2d = drivers.get_driver("oxygen_a2d")
+    timer = drivers.get_driver("timer")
 
     sampler = Sampler(measurements=measurements, events=events,
                       flow_sensor=flow_sensor, pressure_sensor=pressure_sensor,
-                      oxygen_a2d=oxygen_a2d)
+                      oxygen_a2d=oxygen_a2d, timer=timer)
 
     app = Application(measurements=measurements,
                       events=events,


### PR DESCRIPTION
Time is mocked in simulation like any other sensor.
This means you can play the simulation as fast or slow as you want
and it wont affect the calculations in the simulation.

Simulation speed is controlled through the `--sample-rate` CLI argument

Signed-off-by: Avi Shukron <avraham.shukron@gmail.com>