### PR TITLE
Display first alert

### DIFF
--- a/data/alerts.py
+++ b/data/alerts.py
@@ -42,7 +42,11 @@ class Alert(object):
 
     def __init__(self, alert_code, timestamp=None):
         self.code = alert_code
-        self.timestamp = timestamp
+        if timestamp is None:
+            self.timestamp = time.time()
+
+        else:
+            self.timestamp = timestamp
 
     def __eq__(self, other):
         return self.code == other

--- a/graphics/alert_bar.py
+++ b/graphics/alert_bar.py
@@ -31,7 +31,7 @@ class IndicatorAlertBar(object):
                                    fg=Theme.active().ALERT_BAR_OK_TXT,)
 
         self.timestamp_label = Label(master=self.root, font=("Roboto", 12),
-                                     text="Lorem ipsum dolor sit amet",
+                                     text="",
                                      fg=Theme.active().ALERT_BAR_OK_TXT,
                                      bg=Theme.active().ALERT_BAR_OK)
 
@@ -50,8 +50,8 @@ class IndicatorAlertBar(object):
 
     def render(self):
         self.bar.place(relx=0, rely=0)
-        self.message_label.place(anchor="nw", relx=0.03, rely=0.2)
-        self.timestamp_label.place(anchor="nw", relx=0.03, rely=0.8)
+        self.message_label.place(anchor="nw", relx=0.03, rely=0)
+        self.timestamp_label.place(anchor="nw", relx=0.04, rely=0.7)
         self.version_label.place(anchor="nw", relx=0.8, rely=0.4)
 
     def update(self):
@@ -122,4 +122,4 @@ class IndicatorAlertBar(object):
         then_dt = datetime.datetime.fromtimestamp(then)
 
         # This display a '2 minutes ago' text
-        self.timestamp_label.configure(text=timeago.format(now_dt - then_dt))
+        self.timestamp_label.configure(text=f"{(timeago.format(now_dt - then_dt))}")

--- a/graphics/alert_bar.py
+++ b/graphics/alert_bar.py
@@ -1,7 +1,9 @@
 import time
+import timeago
+import datetime
 from tkinter import *
 
-
+from data.alerts import Alert, AlertCodes
 from graphics.themes import Theme
 from data import alerts
 from data.configurations import Configurations
@@ -28,12 +30,19 @@ class IndicatorAlertBar(object):
                                    bg=Theme.active().ALERT_BAR_OK,
                                    fg=Theme.active().ALERT_BAR_OK_TXT,)
 
-        self.version = Label(master=self.root, font=("Roboto", 12),
-                             text="Ver. {}".format(__version__),
-                             fg=Theme.active().ALERT_BAR_OK_TXT,
-                             bg=Theme.active().ALERT_BAR_OK)
+        self.timestamp_label = Label(master=self.root, font=("Roboto", 12),
+                                     text="Lorem ipsum dolor sit amet",
+                                     fg=Theme.active().ALERT_BAR_OK_TXT,
+                                     bg=Theme.active().ALERT_BAR_OK)
+
+        self.version_label = Label(master=self.root, font=("Roboto", 12),
+                                   text="Ver. {}".format(__version__),
+                                   fg=Theme.active().ALERT_BAR_OK_TXT,
+                                   bg=Theme.active().ALERT_BAR_OK)
 
         self.sound_device = drivers.acquire_driver("aux")
+
+        self.current_alert = Alert(AlertCodes.OK)
 
     @property
     def element(self):
@@ -42,7 +51,8 @@ class IndicatorAlertBar(object):
     def render(self):
         self.bar.place(relx=0, rely=0)
         self.message_label.place(anchor="nw", relx=0.03, rely=0.2)
-        self.version.place(anchor="nw", relx=0.8, rely=0.4)
+        self.timestamp_label.place(anchor="nw", relx=0.03, rely=0.8)
+        self.version_label.place(anchor="nw", relx=0.8, rely=0.4)
 
     def update(self):
         # Check mute time limit
@@ -51,29 +61,65 @@ class IndicatorAlertBar(object):
                 self.configs.mute_time_limit):
             self.events.mute_alerts = False
 
-        last_alert = self.events.alerts_queue.last_alert
-        if last_alert == alerts.AlertCodes.OK:
-            self.set_no_alert()
+        last_alert_in_queue = self.events.alerts_queue.last_alert
+
+        # If the queue says everything is ok, and the graphics shows
+        # otherwise, change the graphics state and update the GUI
+        if last_alert_in_queue == AlertCodes.OK:
+            if self.current_alert != AlertCodes.OK:
+                self.current_alert = Alert(AlertCodes.OK)
+                self.set_no_alert()
+
+        # If the queue says there's an issue, and graphics shows
+        # everything to be okay, change the graphics state and update the GUI
         else:
-            self.set_alert(str(last_alert))
+            if self.current_alert == AlertCodes.OK:
+                self.current_alert = last_alert_in_queue
+                self.set_alert(last_alert_in_queue)
+
+        self.update_timestamp_label()
 
     def set_no_alert(self):
         self.bar.config(bg=Theme.active().ALERT_BAR_OK)
         self.message_label.config(bg=Theme.active().ALERT_BAR_OK,
                                   fg=Theme.active().ALERT_BAR_OK_TXT,
                                   text="OK")
-        self.version.config(bg=Theme.active().ALERT_BAR_OK,
-                            fg=Theme.active().ALERT_BAR_OK_TXT)
+        self.version_label.config(bg=Theme.active().ALERT_BAR_OK,
+                                  fg=Theme.active().ALERT_BAR_OK_TXT)
+        self.timestamp_label.config(bg=Theme.active().ALERT_BAR_OK,
+                                    fg=Theme.active().ALERT_BAR_OK_TXT)
+        self.timestamp_label.configure(text="")
         self.sound_device.stop()
 
-    def set_alert(self, message):
+    def set_alert(self, alert: Alert):
         self.bar.config(bg=Theme.active().ERROR)
         self.message_label.config(bg=Theme.active().ERROR,
-                                  fg=Theme.active().TXT_ON_ERROR, text=message)
-        self.version.config(bg=Theme.active().ERROR,
-                            fg=Theme.active().TXT_ON_ERROR)
+                                  fg=Theme.active().TXT_ON_ERROR, text=str(alert))
+        self.version_label.config(bg=Theme.active().ERROR,
+                                  fg=Theme.active().TXT_ON_ERROR)
+        self.timestamp_label.config(bg=Theme.active().ERROR,
+                                    fg=Theme.active().TXT_ON_ERROR)
+
         if self.events.mute_alerts:
             self.sound_device.stop()
 
         else:
             self.sound_device.start()
+
+    def update_timestamp_label(self):
+        if self.current_alert == AlertCodes.OK:
+            self.timestamp_label.configure(text="")
+            return
+
+
+        # We can't use simple alert.date() or time.time() for this calculation
+        # because we want to support both simulation mode and real mode.
+        # hence, we look at the differential time since the alert last happened.
+        now = self.drivers.acquire_driver("timer").get_time()
+        then = self.current_alert.timestamp
+
+        now_dt = datetime.datetime.fromtimestamp(now)
+        then_dt = datetime.datetime.fromtimestamp(then)
+
+        # This display a '2 minutes ago' text
+        self.timestamp_label.configure(text=timeago.format(now_dt - then_dt))

--- a/graphics/alert_bar.py
+++ b/graphics/alert_bar.py
@@ -25,7 +25,7 @@ class IndicatorAlertBar(object):
                          height=self.height, width=self.width)
 
         self.message_label = Label(master=self.bar,
-                                   font=("Roboto", 34),
+                                   font=("Roboto", 32),
                                    text="OK",
                                    bg=Theme.active().ALERT_BAR_OK,
                                    fg=Theme.active().ALERT_BAR_OK_TXT,)
@@ -50,7 +50,7 @@ class IndicatorAlertBar(object):
 
     def render(self):
         self.bar.place(relx=0, rely=0)
-        self.message_label.place(anchor="nw", relx=0.03, rely=0)
+        self.message_label.place(anchor="nw", relx=0.03, rely=0.05)
         self.timestamp_label.place(anchor="nw", relx=0.04, rely=0.7)
         self.version_label.place(anchor="nw", relx=0.8, rely=0.4)
 

--- a/graphics/imagebutton.py
+++ b/graphics/imagebutton.py
@@ -5,7 +5,30 @@ class ImageButton(Button):
     def __init__(self, image_path=NotImplemented, **kw):
         self._image = PhotoImage(file=image_path)
         super(ImageButton, self).__init__(**kw)
-        self.configure(image=self._image)
+        self.command = self["command"]
+        self.bg = self["bg"]
+        self.fg = self["fg"]
+        self.activebackground = self["activebackground"]
+        self.activeforeground = self["activeforeground"]
+
+        self.configure(image=self._image,
+                       activeforeground=self.fg,
+                       activebackground=self.bg)
+        self.bind('<ButtonPress-1>', self.on_press)
+        self.bind('<ButtonRelease-1>', self.on_release)
+
+    def on_press(self, event):
+        if self["state"] != "disabled":
+            self.configure(fg=self.activeforeground,
+                           bg=self.activebackground,
+                           activeforeground=self.activeforeground,
+                           activebackground=self.activebackground)
+
+    def on_release(self, event):
+        self.configure(fg=self.fg,
+                       bg=self.bg,
+                       activebackground=self.bg,
+                       activeforeground=self.fg)
 
     def set_image(self, path):
         self._image = PhotoImage(file=path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ spidev
 cached_property
 numpy
 scipy
+timeago

--- a/tests/unit/graphics/test_alert_bar.py
+++ b/tests/unit/graphics/test_alert_bar.py
@@ -5,7 +5,8 @@ import freezegun
 import pytest
 from unittest.mock import MagicMock
 
-from data.alerts import Alert, AlertCodes
+from data.alerts import Alert, AlertCodes, AlertsQueue
+from drivers.driver_factory import DriverFactory
 from graphics.alert_bar import IndicatorAlertBar
 from graphics.themes import Theme, DarkTheme
 
@@ -17,6 +18,8 @@ def alert_bar() -> IndicatorAlertBar:
     parent.element = Frame()
     events = MagicMock()
     drivers = MagicMock()
+    events.mute_alerts = False
+
     return IndicatorAlertBar(parent=parent, events=events, drivers=drivers)
 
 
@@ -28,15 +31,17 @@ def test_on_alert(alert_bar: IndicatorAlertBar):
     alert_bar.set_alert(Alert(AlertCodes.VOLUME_LOW))
     assert alert_bar.message_label["text"] == "Low Volume"
 
+
 def test_sound_on_alert(alert_bar: IndicatorAlertBar):
-    alert_bar.events.mute_alerts = False
     alert_bar.set_alert(Alert(AlertCodes.VOLUME_LOW))
     assert alert_bar.sound_device.start.called
+
 
 def test_no_sound_on_alert_when_muted(alert_bar: IndicatorAlertBar):
     alert_bar.events.mute_alerts = True
     alert_bar.set_alert(Alert(AlertCodes.VOLUME_LOW))
     assert not alert_bar.sound_device.start.called
+
 
 def test_alert_then_no_alert(alert_bar: IndicatorAlertBar):
     alert_bar.set_alert(Alert(AlertCodes.VOLUME_LOW))
@@ -65,3 +70,95 @@ def test_mute_does_not_disappear_immediately(alert_bar: IndicatorAlertBar):
         alert_bar.update()
 
     assert alert_bar.events.mute_alerts == True
+
+
+def test_alert_on_screen_is_the_first_one(alert_bar: IndicatorAlertBar):
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.VOLUME_LOW)
+    alert_bar.update()
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.VOLUME_HIGH)
+    alert_bar.update()
+    assert alert_bar.message_label["text"] == "Low Volume"
+
+
+def test_alert_on_screen_changes_after_an_ok(alert_bar: IndicatorAlertBar):
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.VOLUME_LOW)
+    alert_bar.update()
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.VOLUME_HIGH)
+    alert_bar.update()
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.OK)
+    alert_bar.update()
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.VOLUME_HIGH)
+    alert_bar.update()
+
+    assert alert_bar.message_label["text"] == "High Volume"
+
+def test_timestamp_label_is_empty_when_there_is_no_alert(alert_bar: IndicatorAlertBar):
+    alert_bar.events.alerts_queue = AlertsQueue()
+    alert_bar.update()
+
+    assert alert_bar.timestamp_label["text"] == ""
+
+def test_timestamp_label_is_empty_when_there_is_an_ok_alert(alert_bar: IndicatorAlertBar):
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.OK)
+
+    alert_bar.update()
+
+    assert alert_bar.timestamp_label["text"] == ""
+
+
+def test_timestamp_label_is_empty_when_alert_changes_to_ok(alert_bar: IndicatorAlertBar):
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.NO_BREATH)
+    alert_bar.update()
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.OK)
+    alert_bar.update()
+
+    assert alert_bar.timestamp_label["text"] == ""
+
+def test_timestamp_label_on_alert(alert_bar: IndicatorAlertBar):
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.NO_BREATH,
+                                                     alert_bar.drivers.acquire_driver("timer").get_time())
+    alert_bar.update()
+
+    assert alert_bar.timestamp_label["text"] == "just now"
+
+
+def test_timestamp_label_on_alert_changes_with_time(alert_bar: IndicatorAlertBar):
+    drivers_factory = MagicMock()
+    alert_bar.drivers = drivers_factory
+
+    drivers_factory.acquire_driver("timer").get_time = MagicMock(return_value=0)
+
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.NO_BREATH, 0)
+    alert_bar.update()
+    assert alert_bar.timestamp_label["text"] == "just now"
+
+    drivers_factory.acquire_driver("timer").get_time = MagicMock(return_value=60*60)
+    alert_bar.update()
+    assert alert_bar.timestamp_label["text"] == "1 hour ago"
+
+
+def test_timestamp_label_resets_on_new_alert(alert_bar: IndicatorAlertBar):
+    drivers_factory = MagicMock()
+    alert_bar.drivers = drivers_factory
+
+    drivers_factory.acquire_driver("timer").get_time = MagicMock(return_value=0)
+
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.NO_BREATH, 0)
+    alert_bar.update()
+    assert alert_bar.timestamp_label["text"] == "just now"
+
+    drivers_factory.acquire_driver("timer").get_time = MagicMock(return_value=60*60)
+    alert_bar.update()
+    assert alert_bar.timestamp_label["text"] == "1 hour ago"
+
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.OK)
+    alert_bar.update()
+
+    alert_bar.events.alerts_queue.last_alert = Alert(AlertCodes.VOLUME_HIGH, 60*60)
+    alert_bar.update()
+    assert alert_bar.timestamp_label["text"] == "just now"
+
+
+def test_version_label(alert_bar: IndicatorAlertBar):
+    from graphics.version import __version__
+    assert __version__ in alert_bar.version_label["text"]


### PR DESCRIPTION
# Summary
Only the first alert is now displayed, meaning that any alert that comes after this one won't be shown.
I've added a timer that displays how long ago the alert happened, for that I used the `timeago` library as our dependency.

## Solves
This issue solves https://github.com/Reznic/Inhalator/issues/166

## Tests
* Test that the alert displayed on screen doesn't change on a new one
* Test that the alert on screen disappears after an OK
* Test timestamp is hidden when no alert is active
* Test timestamp is changing with time
* Test timestamp resets after an OK followed by a new alert


I have also added a test for the version label