### PR TITLE
Auto-scaling both graphs

### DIFF
--- a/graphics/graphs.py
+++ b/graphics/graphs.py
@@ -20,20 +20,15 @@ class BlankGraph(object):
         self.graph_bg = blank_figure.canvas.copy_from_bbox(self.graph_bbox)
 
 class DisplayedGraph(object):
-    LOOSE_GRAPH_FACTOR = 1.2  # Used for calculating the empty space in the Y-axis
+    LOOSE_GRAPH_FACTOR = 3  # Used for calculating the empty space in the Y-axis
 
     # TODO: Move here more similar behaviors between Flow and Pressure graphs
-    def rescale(self, new_miny: float, new_maxy: float, tight: bool=False):
-        """Symmetrically rescale the Y-axis.
-
-        """
+    def rescale(self, new_miny: float, new_maxy: float):
+        """Symmetrically rescale the Y-axis. """
         max_y_difference = max(new_maxy - self.current_max_y, 0)
         min_y_difference = abs(max(self.current_min_y - new_miny, 0))
 
         difference = max(max_y_difference, min_y_difference)
-
-        if not tight:
-            difference *= 1.2
 
         new_miny = self.current_min_y - difference
         new_maxy = self.current_max_y + difference
@@ -44,7 +39,8 @@ class DisplayedGraph(object):
             return
 
         self.current_min_y, self.current_max_y = new_miny, new_maxy
-        self.graph.axes.set_ylim(self.current_min_y, self.current_max_y)
+        self.graph.axes.set_ylim(self.current_min_y - self.LOOSE_GRAPH_FACTOR,
+                                 self.current_max_y + self.LOOSE_GRAPH_FACTOR)
 
         self.render()
 
@@ -138,7 +134,7 @@ class AirPressureGraph(DisplayedGraph):
                                           width=self.width)
 
     def update(self):
-        self.rescale(*self._min_and_max(), tight=False)
+        self.rescale(*self._min_and_max())
         self.figure.canvas.restore_region(self.blank.graph_bg,
                                           bbox=self.blank.graph_bbox,
                                           xy=(0, 0))
@@ -218,7 +214,7 @@ class FlowGraph(DisplayedGraph):
                                           width=self.width)
 
     def update(self):
-        self.rescale(*self._min_and_max(), tight=False)
+        self.rescale(*self._min_and_max())
         self.figure.canvas.restore_region(self.blank.graph_bg,
                                           bbox=self.blank.graph_bbox,
                                           xy=(0, 0))

--- a/graphics/panes.py
+++ b/graphics/panes.py
@@ -128,9 +128,9 @@ class CenterPane(object):
         # Get measurments from peripherals
 
         had_pressure_change = self.pop_queue_to_list(self.measurements.pressure_measurements,
-            self.pressure_graph.pressure_display_values)
+                                                     self.pressure_graph.display_values)
         had_flow_change = self.pop_queue_to_list(self.measurements.flow_measurements,
-            self.flow_graph.flow_display_values)
+                                                 self.flow_graph.display_values)
 
         for graph in self.graphs:
             graph.update()

--- a/tests/unit/graphics/test_graphs.py
+++ b/tests/unit/graphics/test_graphs.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock
+
+import pytest
+from tkinter import *
+
+from pytest import approx
+
+from algo import Sampler
+from data.events import Events
+from data.measurements import Measurements
+from drivers.driver_factory import DriverFactory
+from graphics.graphs import AirPressureGraph, FlowGraph, BlankGraph
+from graphics.themes import Theme, DarkTheme
+
+
+@pytest.fixture
+def events():
+    return Events()
+
+@pytest.fixture
+def measurements():
+    return Measurements()
+
+@pytest.fixture
+def driver_factory():
+    return DriverFactory(simulation_mode=True,
+                         simulation_data="sinus")
+
+@pytest.fixture
+def sampler(measurements, events, driver_factory):
+    flow_sensor = driver_factory.acquire_driver("flow")
+    pressure_sensor = driver_factory.acquire_driver("pressure")
+    a2d = driver_factory.acquire_driver("a2d")
+    timer = driver_factory.acquire_driver("timer")
+    return Sampler(measurements, events, flow_sensor, pressure_sensor,
+                   a2d, timer, average_window=1)
+
+@pytest.fixture
+def pressure_graph(measurements) -> AirPressureGraph:
+    Theme.ACTIVE_THEME = DarkTheme()
+    root = Frame()
+    parent = MagicMock()
+    parent.element = root
+
+    blank = BlankGraph(root)
+    graph = AirPressureGraph(parent=parent, measurements=measurements, blank=blank)
+    graph.axis = MagicMock()
+    graph.figure = MagicMock()
+    return graph
+
+
+def test_graph_doesnt_autoscale_when_it_shouldnt(pressure_graph: AirPressureGraph,
+                                                 sampler: Sampler):
+    original_min = pressure_graph.current_min_y
+    original_max = pressure_graph.current_max_y
+    for _ in range(100):
+        sampler.sampling_iteration()
+
+    pressure_graph.update()
+
+    assert pressure_graph.current_min_y == original_min
+    assert pressure_graph.current_max_y == original_max
+
+
+def test_graph_symmetrically_autoscales_when_value_exceeds_max(pressure_graph: AirPressureGraph):
+    pressure_graph.current_min_y = -10.0
+    pressure_graph.current_max_y = 10.0
+    pressure_graph.LOOSE_GRAPH_FACTOR = 1.2
+
+    x = pressure_graph.measurements._amount_of_samples_in_graph
+
+    pressure_graph.display_values = [10] * x
+    pressure_graph.display_values[1] += 3
+
+    pressure_graph.update()
+
+    assert pressure_graph.current_max_y == approx(10 + (3*1.2))
+    assert pressure_graph.current_min_y == approx(-10.0 - (3*1.2))
+
+
+def test_graph_symmetrically_autoscales_when_value_exceeds_min(pressure_graph: AirPressureGraph):
+    pressure_graph.current_min_y = -10.0
+    pressure_graph.current_max_y = 10.0
+    pressure_graph.LOOSE_GRAPH_FACTOR = 1.2
+
+    x = pressure_graph.measurements._amount_of_samples_in_graph
+
+    pressure_graph.display_values = [-10] * x
+    pressure_graph.display_values[1] -= 3
+
+    pressure_graph.update()
+
+    assert pressure_graph.current_max_y == approx(10 + (3*1.2))
+    assert pressure_graph.current_min_y == approx(-10.0 - (3*1.2))
+


### PR DESCRIPTION
# Summary
Auto-scaling the graphs in a **loose** **symmetric** way. 

Auto-scaling works in this manner:
1. In every iteration, collect minimum and maximum from display values.
2. Find out the biggest differential, who is farther from the display? minimum or maximum? 
3. Increase the current y-limits by this differential + a LOOSE factor (so the graph won't kiss the ceiling)

# Refactors
Both `FlowGraph` and `AirPressureGraph` share similiar code, as of now, all the new code was entered into a new class called `DisplayedGraph` which both graphs inherit from.

Further work is needed to make both graphs actually have NO copy-paste code (Now there is lots), 
This might be done in a future issue, or in this one, per the code reviewers decision. 

# Functionalities Tested
1. Graph doesn't auto-scale when it shouldn't
2. Graph auto-scales symmetrically when minimum is exceeded
3. Graph auto-scales symmetrically when maximum is exceeded
4. Graph auto-scales in a **loose** fashion

# Note!
Please test this pull request for performance on a Raspberry-Pi pior to merging it